### PR TITLE
Support both https and http

### DIFF
--- a/pax-url-aether/pom.xml
+++ b/pax-url-aether/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.ops4j.pax.url</groupId>
     <artifactId>pax-url-aether</artifactId>
-    <version>2.4.5-Talend</version>
+    <version>2.4.6-Talend</version>
     <packaging>bundle</packaging>
 
     <name>OPS4J Pax Url - aether:</name>

--- a/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
+++ b/pax-url-aether/src/main/java/org/ops4j/pax/url/mvn/internal/AetherBasedResolver.java
@@ -305,31 +305,31 @@ public class AetherBasedResolver implements MavenResolver {
             proxySelector.add( proxyObj, nonProxyHosts );
         }
 
-        if(m_settings.getProxies().size() == 0) {
-            javaDefaultProxy(proxySelector);
+        // prefer using maven settings
+        if (m_settings.getProxies().size() == 0) {
+            // support both https and http
+            getJavaProxy(proxySelector, SCHEMA_HTTPS);
+            getJavaProxy(proxySelector, SCHEMA_HTTP);
         }
+
         return proxySelector;
     }
 
-    private void javaDefaultProxy(DefaultProxySelector proxySelector) {
-        // Prefer https
-        String proxyHost = System.getProperty(SCHEMA_HTTPS + "." + PROXY_HOST);
-        String schema = (proxyHost != null) ? SCHEMA_HTTPS : SCHEMA_HTTP;
-        if (proxyHost == null) {
-            proxyHost = System.getProperty(schema + "." + PROXY_HOST);
-        }
-        if(proxyHost == null) {
+    private void getJavaProxy(DefaultProxySelector proxySelector, String schema) {
+        String proxyHost = System.getProperty(schema + '.' + PROXY_HOST);
+        if (proxyHost == null || proxyHost.isEmpty()) {
             return;
         }
+        int proxyPort =  Integer.parseInt(System.getProperty(schema + '.' + PROXY_PORT,"8080"));       
 
-        String proxyUser = System.getProperty(schema + "." + PROXY_USER);
-        String proxyPassword = System.getProperty(schema + "." + PROXY_PASSWORD);
-        int proxyPort = Integer.parseInt(System.getProperty(schema + "." + PROXY_PORT, "8080"));
-        String nonProxyHosts = System.getProperty(schema + "." + NON_PROXY_HOSTS);
-
+        String proxyUser = System.getProperty(schema + '.' + PROXY_USER);
+        String proxyPassword = System.getProperty(schema + '.' + PROXY_PASSWORD);
         Authentication authentication = createAuthentication(proxyUser, proxyPassword);
-        Proxy proxyObj = new Proxy(schema, proxyHost, proxyPort, authentication);
-        proxySelector.add(proxyObj, nonProxyHosts);
+
+        Proxy proxy = new Proxy(schema, proxyHost, proxyPort, authentication);
+        String nonProxyHosts = System.getProperty(schema + '.' + NON_PROXY_HOSTS);
+
+        proxySelector.add(proxy, nonProxyHosts);
     }
 
     private Authentication createAuthentication( String proxyUser, String proxyPassword ) {

--- a/pax-url-aether/src/test/java/org/ops4j/pax/url/mvn/internal/ProxyTest.java
+++ b/pax-url-aether/src/test/java/org/ops4j/pax/url/mvn/internal/ProxyTest.java
@@ -3,6 +3,7 @@ package org.ops4j.pax.url.mvn.internal;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 
+import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.Proxy;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.jetty.server.Handler;
@@ -67,9 +69,13 @@ public class ProxyTest {
 
         System.clearProperty("https.proxyHost");
         System.clearProperty("https.proxyPort");
-
+        System.clearProperty("https.proxyUser");
+        System.clearProperty("https.proxyPassword");
+        
         System.clearProperty("http.proxyHost");
         System.clearProperty("http.proxyPort");
+        System.clearProperty("http.proxyUser");
+        System.clearProperty("http.proxyPassword");
     }
 
     @Test
@@ -150,6 +156,8 @@ public class ProxyTest {
         assertEquals("localhost", proxy.getHost());
         assertEquals(8778, proxy.getPort());
         assertEquals("http", proxy.getType());
+        
+        assertThat(proxy.getAuthentication(), is(nullValue()));
     }
 
     /**
@@ -174,6 +182,33 @@ public class ProxyTest {
         assertEquals("localhost", proxy.getHost());
         assertEquals(8080, proxy.getPort());
         assertEquals("http", proxy.getType());
+        assertThat(proxy.getAuthentication(), is(nullValue()));
+    }
+
+    @Test
+    public void javaHttpProxyWithAuthForHttpURL() throws Exception {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", "8778");
+        System.setProperty("http.proxyUser", "foo");
+        System.setProperty("http.proxyPassword", "bar");
+
+        AetherBasedResolver resolver = createResolver("http");
+        final List<RemoteRepository> repositories = resolver.getRepositories();
+        assertEquals(1, repositories.size());
+
+        final RemoteRepository remoteRepository = repositories.get(0);
+        assertEquals("qfdqfqfqf.fra", remoteRepository.getHost());
+        assertEquals("fake", remoteRepository.getId());
+        assertEquals("http", remoteRepository.getProtocol());
+
+        final Proxy proxy = remoteRepository.getProxy();
+
+        assertEquals("localhost", proxy.getHost());
+        assertEquals(8778, proxy.getPort());
+        assertEquals("http", proxy.getType());
+
+        final Authentication authentication = proxy.getAuthentication();
+        assertNotNull(authentication);
     }
 
     /**
@@ -198,6 +233,7 @@ public class ProxyTest {
         assertEquals("localhost", proxy.getHost());
         assertEquals(8778, proxy.getPort());
         assertEquals("http", proxy.getType());
+        assertThat(proxy.getAuthentication(), is(nullValue()));
     }
 
     /**
@@ -222,6 +258,7 @@ public class ProxyTest {
         assertEquals("localhost", proxy.getHost());
         assertEquals(8778, proxy.getPort());
         assertEquals("https", proxy.getType());
+        assertThat(proxy.getAuthentication(), is(nullValue()));
     }
 
     /**
@@ -247,6 +284,7 @@ public class ProxyTest {
         assertEquals("abc.com", proxy.getHost());
         assertEquals(8080, proxy.getPort());
         assertEquals("http", proxy.getType());
+        assertThat(proxy.getAuthentication(), is(nullValue()));
     }
 
     /**
@@ -272,6 +310,7 @@ public class ProxyTest {
         assertEquals("localhost", proxy.getHost());
         assertEquals(8778, proxy.getPort());
         assertEquals("https", proxy.getType());
+        assertThat(proxy.getAuthentication(), is(nullValue()));
     }
 
     /**

--- a/pax-url-aether/src/test/java/org/ops4j/pax/url/mvn/internal/ProxyTest.java
+++ b/pax-url-aether/src/test/java/org/ops4j/pax/url/mvn/internal/ProxyTest.java
@@ -7,9 +7,12 @@ import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.net.URL;
+import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
 
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.DefaultHandler;
@@ -23,90 +26,274 @@ import org.ops4j.pax.url.mvn.ServiceConstants;
 import org.ops4j.pax.url.mvn.UnitHelp;
 import org.ops4j.pax.url.mvn.internal.config.MavenConfiguration;
 
-public class ProxyTest
-{
+public class ProxyTest {
+
     private static final String TEST_PID = "org.ops4j.pax.url.mvn";
+
     private Server server;
 
+    private String repoPath;
+
+    private File localRepo;
+
     @Before
-    public void startHttp() throws Exception
-    {
+    public void startHttp() throws Exception {
         server = new Server();
         SelectChannelConnector connector = new SelectChannelConnector();
-        connector.setPort( 8778 );
-        server.addConnector( connector );
+        connector.setPort(8778);
+        server.addConnector(connector);
 
         ResourceHandler resource_handler = new ResourceHandler();
-        resource_handler.setDirectoriesListed( false );
-        resource_handler.setWelcomeFiles( new String[]{} );
+        resource_handler.setDirectoriesListed(false);
+        resource_handler.setWelcomeFiles(new String[] {});
 
-        resource_handler.setResourceBase( "target/test-classes/repo2" );
+        resource_handler.setResourceBase("target/test-classes/repo2");
 
         HandlerList handlers = new HandlerList();
-        handlers.setHandlers( new Handler[]{ resource_handler, new DefaultHandler() } );
-        server.setHandler( handlers );
+        handlers.setHandlers(new Handler[] { resource_handler, new DefaultHandler() });
+        server.setHandler(handlers);
 
         server.start();
+
+        repoPath = "target/localrepo_" + UUID.randomUUID();
+        localRepo = new File(repoPath);
+        // you must exist.
+        localRepo.mkdirs();
     }
 
     @After
-    public void stopHttp() throws Exception
-    {
+    public void stopHttp() throws Exception {
         server.stop();
-    }
 
-    @Test
-    public void proxy1() throws Exception
-    {
-        String repoPath = "target/localrepo_" + UUID.randomUUID();
+        System.clearProperty("https.proxyHost");
+        System.clearProperty("https.proxyPort");
 
-        Properties properties = new Properties();
-        properties.setProperty( TEST_PID + "." + ServiceConstants.PROPERTY_LOCAL_REPOSITORY, repoPath );
-        properties.setProperty( TEST_PID + "." + ServiceConstants.PROPERTY_REPOSITORIES,
-            "http://qfdqfqfqf.fra@id=fake" );
-
-        File file = new File( "target/test-classes/settings-proxy1.xml" );
-        MavenConfiguration config = UnitHelp.getConfig( file, properties );
-        File localRepo = new File( repoPath );
-        // you must exist.
-        localRepo.mkdirs();
-
-        Connection c = new Connection( new URL( null, "mvn:ant/ant/1.5.1", new org.ops4j.pax.url.mvn.Handler() ),
-                                       new AetherBasedResolver( config ) );
-        c.getInputStream();
-
-        assertEquals( "the artifact must be downloaded", true, new File( localRepo,
-            "ant/ant/1.5.1/ant-1.5.1.jar" ).exists() );
-        
-        // test for PAXURL-209
-        assertThat( System.getProperty( "http.proxyHost" ), is( nullValue() ) );
-    }
-    
-    @Test
-    public void javaProxy() throws Exception
-    {
-        System.setProperty("http.proxyHost", "localhost");
-        System.setProperty("http.proxyPort", "8778");
-        String repoPath = "target/localrepo_" + UUID.randomUUID();
-
-        Properties properties = new Properties();
-        properties.setProperty( TEST_PID + "." + ServiceConstants.PROPERTY_LOCAL_REPOSITORY, repoPath );
-        properties.setProperty( TEST_PID + "." + ServiceConstants.PROPERTY_REPOSITORIES,
-            "http://qfdqfqfqf.fra@id=fake" );
-
-        File file = new File( "target/test-classes/settings-no-mirror.xml" );
-        MavenConfiguration config = UnitHelp.getConfig( file, properties );
-        File localRepo = new File( repoPath );
-        // you must exist.
-        localRepo.mkdirs();
-
-        Connection c = new Connection( new URL( null, "mvn:ant/ant/1.5.1", new org.ops4j.pax.url.mvn.Handler() ),
-                                       new AetherBasedResolver( config ) );
-        c.getInputStream();
-
-        assertEquals( "the artifact must be downloaded", true, new File( localRepo,
-            "ant/ant/1.5.1/ant-1.5.1.jar" ).exists() );
         System.clearProperty("http.proxyHost");
         System.clearProperty("http.proxyPort");
+    }
+
+    @Test
+    public void proxyHttp() throws Exception {
+        File file = new File("target/test-classes/settings-proxy1.xml");
+
+        Properties settings = new Properties();
+        settings.setProperty(TEST_PID + "." + ServiceConstants.PROPERTY_LOCAL_REPOSITORY, repoPath);
+        settings.setProperty(TEST_PID + "." + ServiceConstants.PROPERTY_REPOSITORIES, "http://qfdqfqfqf.fra@id=fake");
+        MavenConfiguration config = UnitHelp.getConfig(file, settings);
+
+        Connection c =
+                new Connection(new URL(null, "mvn:ant/ant/1.5.1", new org.ops4j.pax.url.mvn.Handler()),
+                        new AetherBasedResolver(config));
+        c.getInputStream();
+
+        assertEquals("the artifact must be downloaded", true,
+                new File(localRepo, "ant/ant/1.5.1/ant-1.5.1.jar").exists());
+
+        // test for PAXURL-209
+        assertThat(System.getProperty("http.proxyHost"), is(nullValue()));
+    }
+
+    @Test
+    public void javaProxy() throws Exception {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", "8778");
+
+        File file = new File("target/test-classes/settings-no-mirror.xml");
+
+        Properties settings = new Properties();
+        settings.setProperty(TEST_PID + "." + ServiceConstants.PROPERTY_LOCAL_REPOSITORY, repoPath);
+        settings.setProperty(TEST_PID + "." + ServiceConstants.PROPERTY_REPOSITORIES, "http://qfdqfqfqf.fra@id=fake");
+        MavenConfiguration config = UnitHelp.getConfig(file, settings);
+
+        Connection c =
+                new Connection(new URL(null, "mvn:ant/ant/1.5.1", new org.ops4j.pax.url.mvn.Handler()),
+                        new AetherBasedResolver(config));
+        c.getInputStream();
+
+        assertEquals("the artifact must be downloaded", true,
+                new File(localRepo, "ant/ant/1.5.1/ant-1.5.1.jar").exists());
+    }
+
+    private AetherBasedResolver createResolver(String schema) {
+        File file = new File("target/test-classes/settings-no-mirror.xml");
+
+        Properties settings = new Properties();
+        settings.setProperty(TEST_PID + "." + ServiceConstants.PROPERTY_LOCAL_REPOSITORY, repoPath);
+        settings.setProperty(TEST_PID + "." + ServiceConstants.PROPERTY_REPOSITORIES, schema
+                + "://qfdqfqfqf.fra@id=fake");
+
+        MavenConfiguration config = UnitHelp.getConfig(file, settings);
+        AetherBasedResolver resolver = new AetherBasedResolver(config);
+        return resolver;
+    }
+
+    /**
+     * Http proxy work well for http URL
+     */
+    @Test
+    public void javaHttpProxyForHttpURL() throws Exception {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", "8778");
+
+        AetherBasedResolver resolver = createResolver("http");
+        final List<RemoteRepository> repositories = resolver.getRepositories();
+        assertEquals(1, repositories.size());
+
+        final RemoteRepository remoteRepository = repositories.get(0);
+        assertEquals("qfdqfqfqf.fra", remoteRepository.getHost());
+        assertEquals("fake", remoteRepository.getId());
+        assertEquals("http", remoteRepository.getProtocol());
+        assertEquals("http://qfdqfqfqf.fra/", remoteRepository.getUrl());
+
+        final Proxy proxy = remoteRepository.getProxy();
+
+        assertEquals("localhost", proxy.getHost());
+        assertEquals(8778, proxy.getPort());
+        assertEquals("http", proxy.getType());
+    }
+
+    /**
+     * Http proxy with default proxy port work well for http URL
+     */
+    @Test
+    public void javaHttpProxyWithouPortForHttpURL() throws Exception {
+        System.setProperty("http.proxyHost", "localhost");
+        // System.setProperty("http.proxyPort", "8778");
+
+        AetherBasedResolver resolver = createResolver("http");
+        final List<RemoteRepository> repositories = resolver.getRepositories();
+        assertEquals(1, repositories.size());
+
+        final RemoteRepository remoteRepository = repositories.get(0);
+        assertEquals("qfdqfqfqf.fra", remoteRepository.getHost());
+        assertEquals("fake", remoteRepository.getId());
+        assertEquals("http", remoteRepository.getProtocol());
+
+        final Proxy proxy = remoteRepository.getProxy();
+
+        assertEquals("localhost", proxy.getHost());
+        assertEquals(8080, proxy.getPort());
+        assertEquals("http", proxy.getType());
+    }
+
+    /**
+     * Http proxy work well for https URL also
+     */
+    @Test
+    public void javaHttpProxyForHttpsURL() throws Exception {
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", "8778");
+
+        AetherBasedResolver resolver = createResolver("https");
+        final List<RemoteRepository> repositories = resolver.getRepositories();
+        assertEquals(1, repositories.size());
+
+        final RemoteRepository remoteRepository = repositories.get(0);
+        assertEquals("qfdqfqfqf.fra", remoteRepository.getHost());
+        assertEquals("fake", remoteRepository.getId());
+        assertEquals("https", remoteRepository.getProtocol());
+
+        final Proxy proxy = remoteRepository.getProxy();
+
+        assertEquals("localhost", proxy.getHost());
+        assertEquals(8778, proxy.getPort());
+        assertEquals("http", proxy.getType());
+    }
+
+    /**
+     * Https proxy work well for https URL
+     */
+    @Test
+    public void javaHttpsProxyForHttpsURL() throws Exception {
+        System.setProperty("https.proxyHost", "localhost");
+        System.setProperty("https.proxyPort", "8778");
+
+        AetherBasedResolver resolver = createResolver("https");
+        final List<RemoteRepository> repositories = resolver.getRepositories();
+        assertEquals(1, repositories.size());
+
+        final RemoteRepository remoteRepository = repositories.get(0);
+        assertEquals("qfdqfqfqf.fra", remoteRepository.getHost());
+        assertEquals("fake", remoteRepository.getId());
+        assertEquals("https", remoteRepository.getProtocol());
+
+        final Proxy proxy = remoteRepository.getProxy();
+
+        assertEquals("localhost", proxy.getHost());
+        assertEquals(8778, proxy.getPort());
+        assertEquals("https", proxy.getType());
+    }
+
+    /**
+     * Http proxy work for http URL always, ignore https proxy
+     */
+    @Test
+    public void javaHttpAndHttpsProxyForHttpURL() throws Exception {
+        System.setProperty("https.proxyHost", "localhost");
+        System.setProperty("https.proxyPort", "8778");
+        System.setProperty("http.proxyHost", "abc.com");
+
+        AetherBasedResolver resolver = createResolver("http");
+        final List<RemoteRepository> repositories = resolver.getRepositories();
+        assertEquals(1, repositories.size());
+
+        final RemoteRepository remoteRepository = repositories.get(0);
+        assertEquals("qfdqfqfqf.fra", remoteRepository.getHost());
+        assertEquals("fake", remoteRepository.getId());
+        assertEquals("http", remoteRepository.getProtocol());
+
+        final Proxy proxy = remoteRepository.getProxy();
+
+        assertEquals("abc.com", proxy.getHost());
+        assertEquals(8080, proxy.getPort());
+        assertEquals("http", proxy.getType());
+    }
+
+    /**
+     * Https proxy work for https URL directly when set both
+     */
+    @Test
+    public void javaHttpAndHttpsProxyForHttpsURL() throws Exception {
+        System.setProperty("https.proxyHost", "localhost");
+        System.setProperty("https.proxyPort", "8778");
+        System.setProperty("http.proxyHost", "abc.com");
+
+        AetherBasedResolver resolver = createResolver("https");
+        final List<RemoteRepository> repositories = resolver.getRepositories();
+        assertEquals(1, repositories.size());
+
+        final RemoteRepository remoteRepository = repositories.get(0);
+        assertEquals("qfdqfqfqf.fra", remoteRepository.getHost());
+        assertEquals("fake", remoteRepository.getId());
+        assertEquals("https", remoteRepository.getProtocol());
+
+        final Proxy proxy = remoteRepository.getProxy();
+
+        assertEquals("localhost", proxy.getHost());
+        assertEquals(8778, proxy.getPort());
+        assertEquals("https", proxy.getType());
+    }
+
+    /**
+     * Https proxy can't work for http URL
+     */
+    @Test
+    public void javaHttpsProxyForHttpURL() throws Exception {
+        System.setProperty("https.proxyHost", "localhost");
+        System.setProperty("https.proxyPort", "8778");
+
+        AetherBasedResolver resolver = createResolver("http");
+        final List<RemoteRepository> repositories = resolver.getRepositories();
+        assertEquals(1, repositories.size());
+
+        final RemoteRepository remoteRepository = repositories.get(0);
+        assertEquals("qfdqfqfqf.fra", remoteRepository.getHost());
+        assertEquals("fake", remoteRepository.getId());
+        assertEquals("http", remoteRepository.getProtocol());
+
+        final Proxy proxy = remoteRepository.getProxy();
+
+        // because https proxy only work for https url
+        assertThat(proxy, is(nullValue()));
     }
 }


### PR DESCRIPTION
Currently, if set both https and http in java properties, use https only.
When url is http, won't work for https proxy. 
So this fixing will add both for MavenResolver (AetherBasedResolver).

